### PR TITLE
Allow predefine a default state strategy.

### DIFF
--- a/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/MvpCompiler.java
+++ b/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/MvpCompiler.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.arellomobile.mvp.GenerateViewState;
@@ -44,6 +45,7 @@ public class MvpCompiler extends AbstractProcessor {
 	private static Messager sMessager;
 	private static Types sTypeUtils;
 	private static Elements sElementUtils;
+	private static Map<String, String> sOptions;
 
 	@Override
 	public synchronized void init(ProcessingEnvironment processingEnv) {
@@ -52,6 +54,7 @@ public class MvpCompiler extends AbstractProcessor {
 		sMessager = processingEnv.getMessager();
 		sTypeUtils = processingEnv.getTypeUtils();
 		sElementUtils = processingEnv.getElementUtils();
+		sOptions = processingEnv.getOptions();
 	}
 
 	public static Messager getMessager() {
@@ -103,7 +106,7 @@ public class MvpCompiler extends AbstractProcessor {
 		processInjectors(roundEnv, InjectViewState.class, ElementKind.CLASS, viewStateProviderClassGenerator);
 		processInjectors(roundEnv, InjectPresenter.class, ElementKind.FIELD, presenterBinderClassGenerator);
 
-		ViewStateClassGenerator viewStateClassGenerator = new ViewStateClassGenerator();
+		ViewStateClassGenerator viewStateClassGenerator = new ViewStateClassGenerator(sOptions);
 		Set<TypeElement> usedViews = viewStateProviderClassGenerator.getUsedViews();
 
 		for (TypeElement usedView : usedViews) {

--- a/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/ViewStateClassGenerator.java
+++ b/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/ViewStateClassGenerator.java
@@ -26,7 +26,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.tools.Diagnostic;
 
-
 import static com.arellomobile.mvp.compiler.Util.fillGenerics;
 
 /**
@@ -38,12 +37,15 @@ import static com.arellomobile.mvp.compiler.Util.fillGenerics;
 final class ViewStateClassGenerator extends ClassGenerator<TypeElement> {
 	public static final String STATE_STRATEGY_TYPE_ANNOTATION = StateStrategyType.class.getName();
 	public static final String DEFAULT_STATE_STRATEGY = AddToEndStrategy.class.getName() + ".class";
+	private static final String DEFAULT_STATE_STRATEGY_OPTION = "defaultStateStrategy";
 
 	private String mViewClassName;
 	private Set<String> mStrategyClasses;
+	private Map<String, String> mOptions;
 
-	public ViewStateClassGenerator() {
+	public ViewStateClassGenerator(Map<String, String> options) {
 		mStrategyClasses = new HashSet<>();
+		mOptions = options;
 	}
 
 	public boolean generate(TypeElement typeElement, List<ClassGeneratingParams> classGeneratingParamsList) {
@@ -235,7 +237,7 @@ final class ViewStateClassGenerator extends ClassGenerator<TypeElement> {
 				MvpCompiler.getMessager().printMessage(Diagnostic.Kind.ERROR, "You are trying generate ViewState for " + typeElement.getSimpleName() + ". But " + typeElement.getSimpleName() + " contains non-void method \"" + methodElement.getSimpleName() + "\" that return type is " + methodElement.getReturnType() + ". See more here: https://github.com/Arello-Mobile/Moxy/issues/2");
 			}
 
-			String strategyClass = defaultStrategy != null ? defaultStrategy : DEFAULT_STATE_STRATEGY;
+			String strategyClass = defaultStrategy != null ? defaultStrategy : getDefaultStateStrategy();
 			String methodTag = "\"" + methodElement.getSimpleName() + "\"";
 			for (AnnotationMirror annotationMirror : methodElement.getAnnotationMirrors()) {
 				if (!annotationMirror.getAnnotationType().asElement().toString().equals(STATE_STRATEGY_TYPE_ANNOTATION)) {
@@ -379,6 +381,13 @@ final class ViewStateClassGenerator extends ClassGenerator<TypeElement> {
 			           "\t}\n";
 		}
 		return builder;
+	}
+
+	private String getDefaultStateStrategy() {
+		if (mOptions.containsKey(DEFAULT_STATE_STRATEGY_OPTION)) {
+			return mOptions.get(DEFAULT_STATE_STRATEGY_OPTION).concat(".class");
+		}
+		return DEFAULT_STATE_STRATEGY;
 	}
 
 	public String getStateStrategyType(TypeElement typeElement) {


### PR DESCRIPTION
Moxy generates `AddToEndStrategy` by default if not specified on view interface. This code allows to define it via gradle config.

Examples for `AddToEndSingleStrategy`, but you can use any valid.

for `apt`:
```groovy
apt {
    arguments {
        defaultStateStrategy  "com.arellomobile.mvp.viewstate.strategy.AddToEndSingleStrategy"
    }
}
```

for `annotationProcessor`:
```groovy
android {
    ...

    defaultConfig {
        ...

        javaCompileOptions {
            annotationProcessorOptions {
                arguments = [ defaultStateStrategy : 'com.arellomobile.mvp.viewstate.strategy.AddToEndSingleStrategy' ]
            }
        }

        ...
    }

    ...
}
```

for `kapt`:
```groovy
kapt {
    arguments {
        arg("defaultStateStrategy", "com.arellomobile.mvp.viewstate.strategy.AddToEndSingleStrategy")
    }
}
```