### PR TITLE
Add ability to destroy view on detach automatically. Fixes bug when u…

### DIFF
--- a/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
+++ b/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
@@ -1,11 +1,11 @@
 package com.arellomobile.mvp;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import android.os.Bundle;
 
 import com.arellomobile.mvp.presenter.PresenterType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Date: 18-Dec-15
@@ -32,16 +32,16 @@ import com.arellomobile.mvp.presenter.PresenterType;
  */
 public class MvpDelegate<Delegated> {
 	private static final String KEY_TAG = "com.arellomobile.mvp.MvpDelegate.KEY_TAG";
-
+	private final Delegated mDelegated;
 	private String mKeyTag = KEY_TAG;
 	private String mDelegateTag;
-	private final Delegated mDelegated;
 	private boolean mIsAttached;
 	private MvpDelegate mParentDelegate;
 	private List<MvpPresenter<? super Delegated>> mPresenters;
 	private List<MvpDelegate> mChildDelegates;
 	private Bundle mBundle;
 	private Bundle mChildKeyTagsBundle;
+	private boolean mDestroyViewOnDetach = false;
 
 	public MvpDelegate(Delegated delegated) {
 		mDelegated = delegated;
@@ -61,6 +61,10 @@ public class MvpDelegate<Delegated> {
 		mKeyTag = mParentDelegate.mKeyTag + "$" + childId;
 
 		delegate.addChildDelegate(this);
+	}
+
+	public void setDestroyViewOnDetach(final boolean destroyViewOnDetach) {
+		this.mDestroyViewOnDetach = destroyViewOnDetach;
 	}
 
 	private void addChildDelegate(MvpDelegate delegate) {
@@ -138,12 +142,18 @@ public class MvpDelegate<Delegated> {
 			}
 
 			presenter.detachView(mDelegated);
+			if (mDestroyViewOnDetach) {
+				presenter.destroyView(mDelegated);
+			}
 		}
 
 		mIsAttached = false;
 
 		for (MvpDelegate<?> childDelegate : mChildDelegates) {
 			childDelegate.onDetach();
+			if (mDestroyViewOnDetach) {
+				childDelegate.onDestroyView();
+			}
 		}
 	}
 

--- a/sample-github/build.gradle
+++ b/sample-github/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     testCompile "org.hamcrest:hamcrest-all:1.3"
     testCompile "org.robolectric:robolectric:3.1-rc1"
 
-    compile 'com.arello-mobile:moxy:1.4.5'
-    compile 'com.arello-mobile:moxy-app-compat:1.4.5'
-    annotationProcessor 'com.arello-mobile:moxy-compiler:1.4.5'
+    compile project(":moxy")
+    compile project(":moxy-app-compat")
+    annotationProcessor project(":moxy-compiler")
 }

--- a/sample-github/src/main/java/com/arellomobile/mvp/sample/github/ui/adapters/RepositoriesAdapter.java
+++ b/sample-github/src/main/java/com/arellomobile/mvp/sample/github/ui/adapters/RepositoriesAdapter.java
@@ -1,8 +1,5 @@
 package com.arellomobile.mvp.sample.github.ui.adapters;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -20,6 +17,9 @@ import com.arellomobile.mvp.sample.github.mvp.presenters.RepositoryLikesPresente
 import com.arellomobile.mvp.sample.github.mvp.presenters.RepositoryPresenter;
 import com.arellomobile.mvp.sample.github.mvp.views.RepositoryLikesView;
 import com.arellomobile.mvp.sample.github.mvp.views.RepositoryView;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -137,25 +137,21 @@ public class RepositoriesAdapter extends MvpBaseAdapter implements RepositoryLik
 		return convertView;
 	}
 
+	public interface OnScrollToBottomListener {
+		void onScrollToBottom();
+	}
+
 	public class RepositoryHolder implements RepositoryView {
 
 		@InjectPresenter
 		RepositoryPresenter mRepositoryPresenter;
-
-		private Repository mRepository;
-
 		@BindView(R.id.item_repository_text_view_name)
 		TextView nameTextView;
 		@BindView(R.id.item_repository_image_button_like)
 		ImageButton likeImageButton;
 		View view;
-
+		private Repository  mRepository;
 		private MvpDelegate mMvpDelegate;
-
-		@ProvidePresenter
-		RepositoryPresenter provideRepositoryPresenter() {
-			return new RepositoryPresenter(mRepository);
-		}
 
 		RepositoryHolder(View view) {
 			this.view = view;
@@ -163,11 +159,15 @@ public class RepositoriesAdapter extends MvpBaseAdapter implements RepositoryLik
 			ButterKnife.bind(this, view);
 		}
 
+		@ProvidePresenter
+		RepositoryPresenter provideRepositoryPresenter() {
+			return new RepositoryPresenter(mRepository);
+		}
+
 		void bind(int position, Repository repository) {
 			if (getMvpDelegate() != null) {
 				getMvpDelegate().onSaveInstanceState();
 				getMvpDelegate().onDetach();
-				getMvpDelegate().onDestroyView();
 				mMvpDelegate = null;
 			}
 
@@ -203,14 +203,11 @@ public class RepositoriesAdapter extends MvpBaseAdapter implements RepositoryLik
 
 			if (mMvpDelegate == null) {
 				mMvpDelegate = new MvpDelegate<>(this);
+				mMvpDelegate.setDestroyViewOnDetach(true);
 				mMvpDelegate.setParentDelegate(RepositoriesAdapter.this.getMvpDelegate(), String.valueOf(mRepository.getId()));
 
 			}
 			return mMvpDelegate;
 		}
-	}
-
-	public interface OnScrollToBottomListener {
-		void onScrollToBottom();
 	}
 }


### PR DESCRIPTION
Added ability to tell MvpDelegate that it must destroy view when `onDetach` is called.
Used when we use MVP in ViewHolder because parent delegate of ViewHolder call `onDetach` but not `onDestroyView` and next `onAttach` will not sometimes apply commands from ViewState to view causing misplaced data.