### PR TITLE
Fixed destroy callback from base fragments when activity is finishing

### DIFF
--- a/moxy-android/src/main/java/com/arellomobile/mvp/MvpDialogFragment.java
+++ b/moxy-android/src/main/java/com/arellomobile/mvp/MvpDialogFragment.java
@@ -59,11 +59,20 @@ public class MvpDialogFragment extends DialogFragment {
 	public void onDestroy() {
 		super.onDestroy();
 
+		//We leave the screen and respectively all fragments will be destroyed
+		if (getActivity().isFinishing()) {
+			getMvpDelegate().onDestroy();
+			return;
+		}
+
+		// When we rotate device isRemoving() return true for fragment placed in backstack
+		// http://stackoverflow.com/questions/34649126/fragment-back-stack-and-isremoving
 		if (mIsStateSaved) {
 			mIsStateSaved = false;
 			return;
 		}
 
+		// See https://github.com/Arello-Mobile/Moxy/issues/24
 		boolean anyParentIsRemoving = false;
 
 		if (Build.VERSION.SDK_INT >= 17) {
@@ -74,7 +83,7 @@ public class MvpDialogFragment extends DialogFragment {
 			}
 		}
 
-		if (isRemoving() || anyParentIsRemoving || getActivity().isFinishing()) {
+		if (isRemoving() || anyParentIsRemoving) {
 			getMvpDelegate().onDestroy();
 		}
 	}

--- a/moxy-android/src/main/java/com/arellomobile/mvp/MvpFragment.java
+++ b/moxy-android/src/main/java/com/arellomobile/mvp/MvpFragment.java
@@ -3,7 +3,6 @@ package com.arellomobile.mvp;
 import android.app.Fragment;
 import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
 
 /**
  * Date: 19-Dec-15
@@ -70,6 +69,11 @@ public class MvpFragment extends Fragment {
 	public void onDestroy() {
 		super.onDestroy();
 
+        if (getActivity().isFinishing()) {
+            getMvpDelegate().onDestroy();
+            return;
+        }
+
 		if (mIsStateSaved) {
 			mIsStateSaved = false;
 			return;
@@ -85,7 +89,7 @@ public class MvpFragment extends Fragment {
 			}
 		}
 
-		if (isRemoving() || anyParentIsRemoving || getActivity().isFinishing()) {
+		if (isRemoving() || anyParentIsRemoving) {
 			getMvpDelegate().onDestroy();
 		}
 	}

--- a/moxy-android/src/main/java/com/arellomobile/mvp/MvpFragment.java
+++ b/moxy-android/src/main/java/com/arellomobile/mvp/MvpFragment.java
@@ -69,16 +69,20 @@ public class MvpFragment extends Fragment {
 	public void onDestroy() {
 		super.onDestroy();
 
-        if (getActivity().isFinishing()) {
-            getMvpDelegate().onDestroy();
-            return;
-        }
+		//We leave the screen and respectively all fragments will be destroyed
+		if (getActivity().isFinishing()) {
+		    getMvpDelegate().onDestroy();
+		    return;
+		}
 
+		// When we rotate device isRemoving() return true for fragment placed in backstack
+		// http://stackoverflow.com/questions/34649126/fragment-back-stack-and-isremoving
 		if (mIsStateSaved) {
 			mIsStateSaved = false;
 			return;
 		}
 
+		// See https://github.com/Arello-Mobile/Moxy/issues/24
 		boolean anyParentIsRemoving = false;
 
 		if (Build.VERSION.SDK_INT >= 17) {

--- a/moxy-android/src/main/java/com/arellomobile/mvp/MvpFragment.java
+++ b/moxy-android/src/main/java/com/arellomobile/mvp/MvpFragment.java
@@ -71,8 +71,8 @@ public class MvpFragment extends Fragment {
 
 		//We leave the screen and respectively all fragments will be destroyed
 		if (getActivity().isFinishing()) {
-		    getMvpDelegate().onDestroy();
-		    return;
+			getMvpDelegate().onDestroy();
+			return;
 		}
 
 		// When we rotate device isRemoving() return true for fragment placed in backstack

--- a/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatDialogFragment.java
+++ b/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatDialogFragment.java
@@ -13,76 +13,85 @@ import android.support.v7.app.AppCompatDialogFragment;
 @SuppressWarnings({"ConstantConditions", "unused"})
 public class MvpAppCompatDialogFragment extends AppCompatDialogFragment {
 
-    private boolean mIsStateSaved;
-    private MvpDelegate<? extends MvpAppCompatDialogFragment> mMvpDelegate;
+	private boolean mIsStateSaved;
+	private MvpDelegate<? extends MvpAppCompatDialogFragment> mMvpDelegate;
 
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
 
-        getMvpDelegate().onCreate(savedInstanceState);
-    }
+		getMvpDelegate().onCreate(savedInstanceState);
+	}
 
-    public void onResume() {
-        super.onResume();
+	public void onResume() {
+		super.onResume();
 
-        mIsStateSaved = false;
+		mIsStateSaved = false;
 
-        getMvpDelegate().onAttach();
-    }
+		getMvpDelegate().onAttach();
+	}
 
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
+	public void onSaveInstanceState(Bundle outState) {
+		super.onSaveInstanceState(outState);
 
-        mIsStateSaved = true;
+		mIsStateSaved = true;
 
-        getMvpDelegate().onSaveInstanceState(outState);
-        getMvpDelegate().onDetach();
-    }
+		getMvpDelegate().onSaveInstanceState(outState);
+		getMvpDelegate().onDetach();
+	}
 
-    @Override
-    public void onStop() {
-        super.onStop();
+	@Override
+	public void onStop() {
+		super.onStop();
 
-        getMvpDelegate().onDetach();
-    }
+		getMvpDelegate().onDetach();
+	}
 
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
+	@Override
+	public void onDestroyView() {
+		super.onDestroyView();
 
-        getMvpDelegate().onDetach();
-        getMvpDelegate().onDestroyView();
-    }
+		getMvpDelegate().onDetach();
+		getMvpDelegate().onDestroyView();
+	}
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
+	@Override
+	public void onDestroy() {
+		super.onDestroy();
 
-        if (mIsStateSaved) {
-            mIsStateSaved = false;
-            return;
-        }
+		//We leave the screen and respectively all fragments will be destroyed
+		if (getActivity().isFinishing()) {
+			getMvpDelegate().onDestroy();
+			return;
+		}
 
-        boolean anyParentIsRemoving = false;
-        Fragment parent = getParentFragment();
-        while (!anyParentIsRemoving && parent != null) {
-            anyParentIsRemoving = parent.isRemoving();
-            parent = parent.getParentFragment();
-        }
+		// When we rotate device isRemoving() return true for fragment placed in backstack
+		// http://stackoverflow.com/questions/34649126/fragment-back-stack-and-isremoving
+		if (mIsStateSaved) {
+			mIsStateSaved = false;
+			return;
+		}
 
-        if (isRemoving() || anyParentIsRemoving || getActivity().isFinishing()) {
-            getMvpDelegate().onDestroy();
-        }
-    }
+		// See https://github.com/Arello-Mobile/Moxy/issues/24
+		boolean anyParentIsRemoving = false;
+		Fragment parent = getParentFragment();
+		while (!anyParentIsRemoving && parent != null) {
+			anyParentIsRemoving = parent.isRemoving();
+			parent = parent.getParentFragment();
+		}
 
-    /**
-     * @return The {@link MvpDelegate} being used by this Fragment.
-     */
-    public MvpDelegate getMvpDelegate() {
-        if (mMvpDelegate == null) {
-            mMvpDelegate = new MvpDelegate<>(this);
-        }
+		if (isRemoving() || anyParentIsRemoving) {
+			getMvpDelegate().onDestroy();
+		}
+	}
 
-        return mMvpDelegate;
-    }
+	/**
+	 * @return The {@link MvpDelegate} being used by this Fragment.
+	 */
+	public MvpDelegate getMvpDelegate() {
+		if (mMvpDelegate == null) {
+			mMvpDelegate = new MvpDelegate<>(this);
+		}
+
+		return mMvpDelegate;
+	}
 }

--- a/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatFragment.java
+++ b/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatFragment.java
@@ -14,94 +14,94 @@ import android.support.v4.app.Fragment;
 @SuppressWarnings({"ConstantConditions", "unused"})
 public class MvpAppCompatFragment extends Fragment {
 
-    private boolean mIsStateSaved;
-    private MvpDelegate<? extends MvpAppCompatFragment> mMvpDelegate;
+	private boolean mIsStateSaved;
+	private MvpDelegate<? extends MvpAppCompatFragment> mMvpDelegate;
 
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
 
-        getMvpDelegate().onCreate(savedInstanceState);
-    }
+		getMvpDelegate().onCreate(savedInstanceState);
+	}
 
-    @Override
-    public void onStart() {
-        super.onStart();
+	@Override
+	public void onStart() {
+		super.onStart();
 
-        mIsStateSaved = false;
+		mIsStateSaved = false;
 
-        getMvpDelegate().onAttach();
-    }
+		getMvpDelegate().onAttach();
+	}
 
-    public void onResume() {
-        super.onResume();
+	public void onResume() {
+		super.onResume();
 
-        mIsStateSaved = false;
+		mIsStateSaved = false;
 
-        getMvpDelegate().onAttach();
-    }
+		getMvpDelegate().onAttach();
+	}
 
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
+	public void onSaveInstanceState(Bundle outState) {
+		super.onSaveInstanceState(outState);
 
-        mIsStateSaved = true;
+		mIsStateSaved = true;
 
-        getMvpDelegate().onSaveInstanceState(outState);
-        getMvpDelegate().onDetach();
-    }
+		getMvpDelegate().onSaveInstanceState(outState);
+		getMvpDelegate().onDetach();
+	}
 
-    @Override
-    public void onStop() {
-        super.onStop();
+	@Override
+	public void onStop() {
+		super.onStop();
 
-        getMvpDelegate().onDetach();
-    }
+		getMvpDelegate().onDetach();
+	}
 
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
+	@Override
+	public void onDestroyView() {
+		super.onDestroyView();
 
-        getMvpDelegate().onDetach();
-        getMvpDelegate().onDestroyView();
-    }
+		getMvpDelegate().onDetach();
+		getMvpDelegate().onDestroyView();
+	}
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
+	@Override
+	public void onDestroy() {
+		super.onDestroy();
 
-        //We leave the screen and respectively all fragments will be destroyed
-        if (getActivity().isFinishing()) {
-            getMvpDelegate().onDestroy();
-            return;
-        }
+		//We leave the screen and respectively all fragments will be destroyed
+		if (getActivity().isFinishing()) {
+			getMvpDelegate().onDestroy();
+			return;
+		}
 
-        // When we rotate device isRemoving() return true for fragment placed in backstack
-        // http://stackoverflow.com/questions/34649126/fragment-back-stack-and-isremoving
-        if (mIsStateSaved) {
-            mIsStateSaved = false;
-            return;
-        }
+		// When we rotate device isRemoving() return true for fragment placed in backstack
+		// http://stackoverflow.com/questions/34649126/fragment-back-stack-and-isremoving
+		if (mIsStateSaved) {
+			mIsStateSaved = false;
+			return;
+		}
 
-        // See https://github.com/Arello-Mobile/Moxy/issues/24
-        boolean anyParentIsRemoving = false;
-        Fragment parent = getParentFragment();
-        while (!anyParentIsRemoving && parent != null) {
-            anyParentIsRemoving = parent.isRemoving();
-            parent = parent.getParentFragment();
-        }
+		// See https://github.com/Arello-Mobile/Moxy/issues/24
+		boolean anyParentIsRemoving = false;
+		Fragment parent = getParentFragment();
+		while (!anyParentIsRemoving && parent != null) {
+			anyParentIsRemoving = parent.isRemoving();
+			parent = parent.getParentFragment();
+		}
 
-        if (isRemoving() || anyParentIsRemoving) {
-            getMvpDelegate().onDestroy();
-        }
-    }
+		if (isRemoving() || anyParentIsRemoving) {
+			getMvpDelegate().onDestroy();
+		}
+	}
 
-    /**
-     * @return The {@link MvpDelegate} being used by this Fragment.
-     */
-    public MvpDelegate getMvpDelegate() {
-        if (mMvpDelegate == null) {
-            mMvpDelegate = new MvpDelegate<>(this);
-        }
+	/**
+	 * @return The {@link MvpDelegate} being used by this Fragment.
+	 */
+	public MvpDelegate getMvpDelegate() {
+		if (mMvpDelegate == null) {
+			mMvpDelegate = new MvpDelegate<>(this);
+		}
 
-        return mMvpDelegate;
-    }
+		return mMvpDelegate;
+	}
 }

--- a/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatFragment.java
+++ b/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatFragment.java
@@ -68,6 +68,11 @@ public class MvpAppCompatFragment extends Fragment {
 	public void onDestroy() {
 		super.onDestroy();
 
+        if (getActivity().isFinishing()) {
+            getMvpDelegate().onDestroy();
+            return;
+        }
+
 		if (mIsStateSaved) {
 			mIsStateSaved = false;
 			return;
@@ -80,7 +85,7 @@ public class MvpAppCompatFragment extends Fragment {
 			parent = parent.getParentFragment();
 		}
 
-		if (isRemoving() || anyParentIsRemoving || getActivity().isFinishing()) {
+		if (isRemoving() || anyParentIsRemoving) {
 			getMvpDelegate().onDestroy();
 		}
 	}

--- a/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatFragment.java
+++ b/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatFragment.java
@@ -14,90 +14,94 @@ import android.support.v4.app.Fragment;
 @SuppressWarnings({"ConstantConditions", "unused"})
 public class MvpAppCompatFragment extends Fragment {
 
-	private boolean mIsStateSaved;
-	private MvpDelegate<? extends MvpAppCompatFragment> mMvpDelegate;
+    private boolean mIsStateSaved;
+    private MvpDelegate<? extends MvpAppCompatFragment> mMvpDelegate;
 
-	public void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
-		getMvpDelegate().onCreate(savedInstanceState);
-	}
+        getMvpDelegate().onCreate(savedInstanceState);
+    }
 
-	@Override
-	public void onStart() {
-		super.onStart();
+    @Override
+    public void onStart() {
+        super.onStart();
 
-		mIsStateSaved = false;
+        mIsStateSaved = false;
 
-		getMvpDelegate().onAttach();
-	}
+        getMvpDelegate().onAttach();
+    }
 
-	public void onResume() {
-		super.onResume();
+    public void onResume() {
+        super.onResume();
 
-		mIsStateSaved = false;
+        mIsStateSaved = false;
 
-		getMvpDelegate().onAttach();
-	}
+        getMvpDelegate().onAttach();
+    }
 
-	public void onSaveInstanceState(Bundle outState) {
-		super.onSaveInstanceState(outState);
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
 
-		mIsStateSaved = true;
+        mIsStateSaved = true;
 
-		getMvpDelegate().onSaveInstanceState(outState);
-		getMvpDelegate().onDetach();
-	}
+        getMvpDelegate().onSaveInstanceState(outState);
+        getMvpDelegate().onDetach();
+    }
 
-	@Override
-	public void onStop() {
-		super.onStop();
+    @Override
+    public void onStop() {
+        super.onStop();
 
-		getMvpDelegate().onDetach();
-	}
+        getMvpDelegate().onDetach();
+    }
 
-	@Override
-	public void onDestroyView() {
-		super.onDestroyView();
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
 
-		getMvpDelegate().onDetach();
-		getMvpDelegate().onDestroyView();
-	}
+        getMvpDelegate().onDetach();
+        getMvpDelegate().onDestroyView();
+    }
 
-	@Override
-	public void onDestroy() {
-		super.onDestroy();
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
 
+        //We leave the screen and respectively all fragments will be destroyed
         if (getActivity().isFinishing()) {
             getMvpDelegate().onDestroy();
             return;
         }
 
-		if (mIsStateSaved) {
-			mIsStateSaved = false;
-			return;
-		}
+        // When we rotate device isRemoving() return true for fragment placed in backstack
+        // http://stackoverflow.com/questions/34649126/fragment-back-stack-and-isremoving
+        if (mIsStateSaved) {
+            mIsStateSaved = false;
+            return;
+        }
 
-		boolean anyParentIsRemoving = false;
-		Fragment parent = getParentFragment();
-		while (!anyParentIsRemoving && parent != null) {
-			anyParentIsRemoving = parent.isRemoving();
-			parent = parent.getParentFragment();
-		}
+        // See https://github.com/Arello-Mobile/Moxy/issues/24
+        boolean anyParentIsRemoving = false;
+        Fragment parent = getParentFragment();
+        while (!anyParentIsRemoving && parent != null) {
+            anyParentIsRemoving = parent.isRemoving();
+            parent = parent.getParentFragment();
+        }
 
-		if (isRemoving() || anyParentIsRemoving) {
-			getMvpDelegate().onDestroy();
-		}
-	}
+        if (isRemoving() || anyParentIsRemoving) {
+            getMvpDelegate().onDestroy();
+        }
+    }
 
-	/**
-	 * @return The {@link MvpDelegate} being used by this Fragment.
-	 */
-	public MvpDelegate getMvpDelegate() {
-		if (mMvpDelegate == null) {
-			mMvpDelegate = new MvpDelegate<>(this);
-		}
+    /**
+     * @return The {@link MvpDelegate} being used by this Fragment.
+     */
+    public MvpDelegate getMvpDelegate() {
+        if (mMvpDelegate == null) {
+            mMvpDelegate = new MvpDelegate<>(this);
+        }
 
-		return mMvpDelegate;
-	}
+        return mMvpDelegate;
+    }
 }


### PR DESCRIPTION
We have memory leaks when activity is finishing in background (onSaveInstanceState was called and mIsStateSaved = true). This is possible when the application in background. At this moment we open the new activity by click on notification and set launch flag Intent.FLAG_ACTIVITY_CLEAR_TOP. All activities on the top will be closed, but fragments will not called onDestroy on presenters.