### PR TITLE
Kotlin sample fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,13 @@ dependencies {
 }
 ```
 ### Kotlin
-If you are using kotlin, use `kapt` instead of `provided`/`apt` dependency type and set `generateStubs` property of `kapt` to `true`:
+If you are using kotlin, use `kapt` instead of `provided`/`apt` dependency type and add `kotlin-kapt` plugin:
 ```groovy
+apply plugin: 'kotlin-kapt'
+
 dependencies {
   ...
   kapt 'com.arello-mobile:moxy-compiler:1.5.3'
-}
-kapt {
-    generateStubs = true
 }
 ```
 

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.0.5'
+    ext.kotlin_version = '1.2.10'
     repositories {
         jcenter()
         mavenCentral()
@@ -11,38 +11,43 @@ buildscript {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.arellomobile.mvp.sample.kotlin"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.0.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
 
     compile 'com.arello-mobile:moxy:1.5.3'
     compile 'com.arello-mobile:moxy-app-compat:1.5.3'
     kapt 'com.arello-mobile:moxy-compiler:1.5.3'
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }

--- a/sample-kotlin/src/main/kotlin/com/arellomobile/mvp/sample/kotlin/MainActivity.kt
+++ b/sample-kotlin/src/main/kotlin/com/arellomobile/mvp/sample/kotlin/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.arellomobile.mvp.sample.kotlin
 
-
 import android.os.Bundle
 import android.support.v7.app.AlertDialog
 import com.arellomobile.mvp.MvpAppCompatActivity
@@ -8,6 +7,7 @@ import com.arellomobile.mvp.presenter.InjectPresenter
 import com.arellomobile.mvp.presenter.PresenterType
 import com.arellomobile.mvp.presenter.ProvidePresenter
 import com.arellomobile.mvp.presenter.ProvidePresenterTag
+import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : MvpAppCompatActivity(), DialogView {
 
@@ -26,19 +26,19 @@ class MainActivity : MvpAppCompatActivity(), DialogView {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        findViewById(R.id.activity_main).setOnClickListener { dialogPresenter.onShowDialogClick() }
+        rootView.setOnClickListener { dialogPresenter.onShowDialogClick() }
     }
 
     override fun showDialog() {
         alertDialog = AlertDialog.Builder(this)
-                .setTitle("Title")
-                .setMessage("Message")
-                .setOnDismissListener { dialogPresenter.onHideDialog() }
-                .show()
+            .setTitle("Title")
+            .setMessage("Message")
+            .setOnDismissListener { dialogPresenter.onHideDialog() }
+            .show()
     }
 
     override fun hideDialog() {
-        alertDialog?.setOnDismissListener {  }
+        alertDialog?.setOnDismissListener { }
         alertDialog?.cancel()
     }
 

--- a/sample-kotlin/src/main/res/layout/activity_main.xml
+++ b/sample-kotlin/src/main/res/layout/activity_main.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:tools="http://schemas.android.com/tools"
-	android:id="@+id/activity_main"
-	android:layout_width="match_parent"
-	android:layout_height="match_parent"
-	android:paddingBottom="@dimen/activity_vertical_margin"
-	android:paddingLeft="@dimen/activity_horizontal_margin"
-	android:paddingRight="@dimen/activity_horizontal_margin"
-	android:paddingTop="@dimen/activity_vertical_margin"
-	tools:context="com.arellomobile.mvp.sample.kotlin.MainActivity">
+<FrameLayout android:id="@+id/rootView"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context="com.arellomobile.mvp.sample.kotlin.MainActivity"
+    >
 
-	<TextView android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:text="Hello World!" />
-</RelativeLayout>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!"
+        />
+</FrameLayout>


### PR DESCRIPTION
I can't build current sample version with working moxy, so in this PR I update it with following to be able to build apk with generated moxy classes:

 - update kotlin version
 - add kotlin android-extensions plugin
 - use `kotlin-kapt` plugin
 - update android support lib, compileSdkVersion and targetSdkVersion to 26
 - set compileOptions.sourceCompatibility to 1.8
 - update README (kotlin part)
 - some refactoring