### PR TITLE
 Fix memory leak in parent delegate using custom view with MVP

### DIFF
--- a/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
+++ b/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
@@ -71,14 +71,18 @@ public class MvpDelegate<Delegated> {
 		mChildDelegates.remove(delegate);
 	}
 
-	public void removeParentDelegate() {
+	/**
+	 * Free self link from children list (mChildDelegates) in parent delegate
+	 * property mParentDelegate stay keep link to parent delegate for access to
+	 * parent bundle for save state in {@link #onSaveInstanceState()}
+	 */
+	public void freeParentDelegate() {
 
 		if (mParentDelegate == null) {
-			throw new IllegalStateException("You should call removeParentDelegate() before first setParentDelegate()");
+			throw new IllegalStateException("You should call freeParentDelegate() before first setParentDelegate()");
 		}
 
 		mParentDelegate.removeChildDelegate(this);
-		mParentDelegate = null;
 	}
 
 	public void removeAllChildDelegates()
@@ -88,7 +92,7 @@ public class MvpDelegate<Delegated> {
 		childDelegatesClone.addAll(mChildDelegates);
 
 		for (MvpDelegate childDelegate : childDelegatesClone) {
-			childDelegate.removeParentDelegate();
+			childDelegate.freeParentDelegate();
 		}
 
 		mChildDelegates = new ArrayList<>();
@@ -194,7 +198,7 @@ public class MvpDelegate<Delegated> {
 		}
 
 		if (mParentDelegate != null) {
-			removeParentDelegate();
+			freeParentDelegate();
 		}
 	}
 

--- a/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
+++ b/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
@@ -185,7 +185,11 @@ public class MvpDelegate<Delegated> {
 			presenter.destroyView(mDelegated);
 		}
 
-		for (MvpDelegate<?> childDelegate : mChildDelegates) {
+		// For avoiding ConcurrentModificationException when removing from mChildDelegates
+		List<MvpDelegate> childDelegatesClone = new ArrayList<MvpDelegate>(mChildDelegates.size());
+		childDelegatesClone.addAll(mChildDelegates);
+
+		for (MvpDelegate childDelegate : childDelegatesClone) {
 			childDelegate.onDestroyView();
 		}
 

--- a/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
+++ b/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
@@ -67,6 +67,33 @@ public class MvpDelegate<Delegated> {
 		mChildDelegates.add(delegate);
 	}
 
+	private void removeChildDelegate(MvpDelegate delegate) {
+		mChildDelegates.remove(delegate);
+	}
+
+	public void removeParentDelegate() {
+
+		if (mParentDelegate == null) {
+			throw new IllegalStateException("You should call removeParentDelegate() before first setParentDelegate()");
+		}
+
+		mParentDelegate.removeChildDelegate(this);
+		mParentDelegate = null;
+	}
+
+	public void removeAllChildDelegates()
+	{
+		// For avoiding ConcurrentModificationException when removing by removeChildDelegate()
+		List<MvpDelegate> childDelegatesClone = new ArrayList<MvpDelegate>(mChildDelegates.size());
+		childDelegatesClone.addAll(mChildDelegates);
+
+		for (MvpDelegate childDelegate : childDelegatesClone) {
+			childDelegate.removeParentDelegate();
+		}
+
+		mChildDelegates = new ArrayList<>();
+	}
+
 	/**
 	 * <p>Similar like {@link #onCreate(Bundle)}. But this method try to get saved
 	 * state from parent presenter before get presenters</p>
@@ -160,6 +187,10 @@ public class MvpDelegate<Delegated> {
 
 		for (MvpDelegate<?> childDelegate : mChildDelegates) {
 			childDelegate.onDestroyView();
+		}
+
+		if (mParentDelegate != null) {
+			removeParentDelegate();
 		}
 	}
 


### PR DESCRIPTION
Fix #179

Более детально опишу проблему описанную @daniil-vinogradov в #179

1. Задача: Есть 2 фрагмента. По кнопке из первого фрагмента переходим на второй, сохраняя первый в стеке. Из второго фрагмента по кнопке Back возвращаемся обратно на первый фрагмент.
2. В первом фрагменте имеется `CustomView` c MVP. Каждый раз при показе первого фрагмента, при создании его view через inflate создается новый объект класса `CustomView` в котором нужно проинициализировать MVP. 
3. Инициализация MVP заключается в создании своего делегата у `CustomView` и привязке его к родительскому (к делегату фрагмента) через метод `MvpDelegate::setParentDelegate()`. В этом методе происходит двойное связывание родительского и дочернего делегатов. Родительский делегат начинает хранить ссылки на дочерний (вызов `delegate.addChildDelegate(this)`)
5. При переходе на второй фрагмент, объект класса первого фрагмента не уничтожается, а сохраняется в стеке (`onDestroy()` у него не вызывается) и его делегат тоже продолжает жить. А вот весь его view уничтожается (вызывается `onDestroyView()`) вместе c `CustomView`. Однако родительский делегат всё равно продолжает хранить ссылку на `CustomView` (в поле `MvpDelegate::mChildDelegates`). И нет никакой нормальной возможности его отвязать. **Вот тут происходит утечка памяти.** 
6. При возврате обратно на первый фрагмент, layout создаётся заново, создается новый объект `CustomView` и его делегат ещё раз добавляется в родительский. Таким образом там уже 2 ссылки, на старый `CustomView` и на новый. Далее происходит передача событий (`onAttach` `onDetach` и т.д.) а также команд в дочерний делегат умершего `CustomView`.
7. При перевороте экрана такого не происходит, так как первый фрагмент пересоздается вместе с делегатом.

Проект воспроизводимый этот баг https://github.com/daniil-vinogradov/MoxyIssue

**Решение проблемы.** 

По сути я вижу 2 варианта решения проблемы. 
- Сделать так чтобы родители занимались удалением детей 
- Чтобы дети сами удаляли себя у родителя.

Я сначала сделал вариант 1 (ветка [fix-179-remove-child-delegates ](https://github.com/rsajob/Moxy/tree/fix-179-remove-child-delegates) ), для этого в `MvpDelegate` добавил метод `removeAllChildDelegates()`. Потоп подумал, а что если у нас иерархия из нескольких CustomView. Получается в самом CustomView мы никак не сможем понять о том что происходит уничтожение т.к. у `View` нет методов жизненного цикла. Поэтому сообщить об уничтожении может только родительский делегат вызовом `childDelegate.onDestroyView()`. Таким образом всё таки ребёнок должен сам себя удалять у родителя (вариант 2) и это должно делаться автоматически по всей иерархии.

Метод `removeAllChildDelegates()` я на всякий случай оставил для ручного вмешательства. Но его можно удалить чтобы не сбивал столку. 

Ещё нужно подумать по поводу `mKeyTag` при удалении родителя. Если его менять то теоретически не получится найти презентер по `mDelegateTag`. Пока не стал его менять. 

Мне кажется тут ещё могут быть нюансы. Нужен совет разработчиков библиотеки. 

  