### PR TITLE
After restarting the activity from the stack, presenters of its fragments are created earlier than the presenter of the activity itself

### DIFF
--- a/moxy-android/src/main/java/com/arellomobile/mvp/MvpActivity.java
+++ b/moxy-android/src/main/java/com/arellomobile/mvp/MvpActivity.java
@@ -16,9 +16,9 @@ public class MvpActivity extends Activity {
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-
 		getMvpDelegate().onCreate(savedInstanceState);
+
+		super.onCreate(savedInstanceState);
 	}
 
 	@Override

--- a/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatActivity.java
+++ b/moxy-app-compat/src/main/java/com/arellomobile/mvp/MvpAppCompatActivity.java
@@ -17,9 +17,9 @@ public class MvpAppCompatActivity extends AppCompatActivity {
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-
 		getMvpDelegate().onCreate(savedInstanceState);
+
+		super.onCreate(savedInstanceState);
 	}
 
 	@Override


### PR DESCRIPTION
How did I come to this:

There is activity, there are many nested fragments in it. Activity has a presenter, each fragment also has a presenter. Activity triggers another activity that falls (why - it does not matter in this matter). After crashing, the system recreates the activity stack and starts the previous activity with a bunch of fragments.

However, the activity has the starting data, which lies in the content. Passing these data to fragments through arguments is long and painful (there are a lot of them, they are nested in each other) - so I pass them through di (I use dagger2). The presenter of the activity is in the component, the presenters of the fragments are in the subcomponents of the activity component. And under this order of creation, the subcomponent tries to create before its parent component, as a result, everything flies to hell.

This [answer](https://stackoverflow.com/a/30222913/5541688) explains the behavior, there is no turning of the device, because the presenters are not created when turning, but the situation is similar.

Yes, of course, the application should work stably and without crashes. However, in this situation, I get crash from moxy in analytics(fabric), and I do not see the root causes of crashes(maybe problem in analytics, i don't know). It is also possible that there are other ways to get this behavior.

How I solved the problem:

I created my own MvpActivity, where I called getMvpDelegate().onCreate() before calling super.onCreate(savedInstanceState).

I think this behavior should be in the library by default.

