### PR TITLE
Minor improvement for templates

### DIFF
--- a/moxy-templates/Kotlin/MoxyFragment/root/src/app_package/ui/fragment/BlankFragment.kt.ftl
+++ b/moxy-templates/Kotlin/MoxyFragment/root/src/app_package/ui/fragment/BlankFragment.kt.ftl
@@ -35,7 +35,7 @@ class ${className} : MvpFragment(), ${viewName} {
 </#if>
     }
 
-    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
     }


### PR DESCRIPTION
Updated kotlin fragment template for support lib >= 27
As we know in v27 support library team added @NonNull in some lifecycle callbacks, including "onViewCreated". So, after using current template we're getting this error:
![selection_999 230](https://user-images.githubusercontent.com/12698708/47297971-0eceac80-d630-11e8-9cd6-77d87f191f8a.png)
Guess, most of developers already using support lib 27 or higher (v27 have been released half-year ago).

P.S. Biggest PR i've ever seen :D Cheers!