### PR TITLE
Fix types of parameters in methods from generic superinterfaces

### DIFF
--- a/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/viewstate/ViewInterfaceInfo.java
+++ b/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/viewstate/ViewInterfaceInfo.java
@@ -1,6 +1,5 @@
 package com.arellomobile.mvp.compiler.viewstate;
 
-import com.google.common.collect.Iterables;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
@@ -18,17 +17,23 @@ import javax.lang.model.element.TypeElement;
  * @author Evgeny Kursakov
  */
 class ViewInterfaceInfo {
+	private final TypeElement element;
 	private final ClassName name;
 	private final List<TypeVariableName> typeVariables;
 	private final List<ViewMethod> methods;
 
-	ViewInterfaceInfo(TypeElement name, List<ViewMethod> methods) {
-		this.name = ClassName.get(name);
+	ViewInterfaceInfo(TypeElement element, List<ViewMethod> methods) {
+		this.element = element;
+		this.name = ClassName.get(element);
 		this.methods = methods;
 
-		this.typeVariables = name.getTypeParameters().stream()
+		this.typeVariables = element.getTypeParameters().stream()
 				.map(TypeVariableName::get)
 				.collect(Collectors.toList());
+	}
+
+	public TypeElement getElement() {
+		return element;
 	}
 
 	ClassName getName() {

--- a/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/viewstate/ViewInterfaceProcessor.java
+++ b/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/viewstate/ViewInterfaceProcessor.java
@@ -37,7 +37,8 @@ public class ViewInterfaceProcessor extends ElementProcessor<TypeElement, ViewIn
 	private static final String STATE_STRATEGY_TYPE_ANNOTATION = StateStrategyType.class.getName();
 	private static final TypeElement DEFAULT_STATE_STRATEGY = MvpCompiler.getElementUtils().getTypeElement(AddToEndStrategy.class.getCanonicalName());
 
-	private String viewClassName;
+	private TypeElement viewInterfaceElement;
+	private String viewInterfaceName;
 	private Set<TypeElement> usedStrategies = new HashSet<>();
 
 	public List<TypeElement> getUsedStrategies() {
@@ -46,7 +47,8 @@ public class ViewInterfaceProcessor extends ElementProcessor<TypeElement, ViewIn
 
 	@Override
 	public ViewInterfaceInfo process(TypeElement element) {
-		viewClassName = element.getSimpleName().toString();
+		this.viewInterfaceElement = element;
+		viewInterfaceName = element.getSimpleName().toString();
 
 		List<ViewMethod> methods = new ArrayList<>();
 
@@ -126,7 +128,9 @@ public class ViewInterfaceProcessor extends ElementProcessor<TypeElement, ViewIn
 			// add strategy to list
 			usedStrategies.add(strategyClass);
 
-			final ViewMethod method = new ViewMethod(methodElement, strategyClass, methodTag);
+			final ViewMethod method = new ViewMethod(
+					(DeclaredType) viewInterfaceElement.asType(), methodElement, strategyClass, methodTag
+			);
 
 			if (rootMethods.contains(method)) {
 				continue;
@@ -161,7 +165,7 @@ public class ViewInterfaceProcessor extends ElementProcessor<TypeElement, ViewIn
 					" and " + method.getEnclosedClassName() +
 					" has method " + method.getName() + "(" + arguments + ")" +
 					" with different " + parts + "." +
-					" Override this method in " + viewClassName + " or make " + parts + " equals");
+					" Override this method in " + viewInterfaceName + " or make " + parts + " equals");
 		}
 	}
 

--- a/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/viewstate/ViewMethod.java
+++ b/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/viewstate/ViewMethod.java
@@ -1,14 +1,21 @@
 package com.arellomobile.mvp.compiler.viewstate;
 
+import com.arellomobile.mvp.compiler.MvpCompiler;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeVariableName;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
 
 /**
  * Date: 27-Jul-2017
@@ -17,7 +24,7 @@ import javax.lang.model.element.TypeElement;
  * @author Evgeny Kursakov
  */
 class ViewMethod {
-	private final ExecutableElement element;
+	private final ExecutableElement methodElement;
 	private final String name;
 	private final TypeElement strategy;
 	private final String tag;
@@ -28,18 +35,32 @@ class ViewMethod {
 
 	private String uniqueSuffix;
 
-	ViewMethod(ExecutableElement methodElement,
+	ViewMethod(DeclaredType targetInterfaceElement,
+	           ExecutableElement methodElement,
 	           TypeElement strategy,
 	           String tag) {
-		this.element = methodElement;
+		this.methodElement = methodElement;
 		this.name = methodElement.getSimpleName().toString();
 		this.strategy = strategy;
 		this.tag = tag;
 
-		this.parameterSpecs = methodElement.getParameters()
-				.stream()
-				.map(ParameterSpec::get)
-				.collect(Collectors.toList());
+		this.parameterSpecs = new ArrayList<>();
+
+		Types typeUtils = MvpCompiler.getTypeUtils();
+		ExecutableType executableType = (ExecutableType) typeUtils.asMemberOf(targetInterfaceElement, methodElement);
+		List<? extends VariableElement> parameters = methodElement.getParameters();
+		List<? extends TypeMirror> resolvedParameterTypes = executableType.getParameterTypes();
+
+		for (int i = 0; i < parameters.size(); i++) {
+			VariableElement element = parameters.get(i);
+			TypeName type = TypeName.get(resolvedParameterTypes.get(i));
+			String name = element.getSimpleName().toString();
+
+			parameterSpecs.add(ParameterSpec.builder(type, name)
+					.addModifiers(element.getModifiers())
+					.build()
+			);
+		}
 
 		this.exceptions = methodElement.getThrownTypes().stream()
 				.map(TypeName::get)
@@ -50,7 +71,7 @@ class ViewMethod {
 				.map(TypeVariableName::get)
 				.collect(Collectors.toList());
 
-		this.argumentsString = parameterSpecs.stream()
+		this.argumentsString = this.parameterSpecs.stream()
 				.map(parameterSpec -> parameterSpec.name)
 				.collect(Collectors.joining(", "));
 
@@ -58,7 +79,7 @@ class ViewMethod {
 	}
 
 	ExecutableElement getElement() {
-		return element;
+		return methodElement;
 	}
 
 	String getName() {
@@ -94,7 +115,7 @@ class ViewMethod {
 	}
 
 	String getEnclosedClassName() {
-		TypeElement typeElement = (TypeElement) element.getEnclosingElement();
+		TypeElement typeElement = (TypeElement) methodElement.getEnclosingElement();
 		return typeElement.getQualifiedName().toString();
 	}
 

--- a/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/viewstate/ViewStateClassGenerator.java
+++ b/moxy-compiler/src/main/java/com/arellomobile/mvp/compiler/viewstate/ViewStateClassGenerator.java
@@ -2,6 +2,7 @@ package com.arellomobile.mvp.compiler.viewstate;
 
 import com.arellomobile.mvp.MvpProcessor;
 import com.arellomobile.mvp.compiler.JavaFilesGenerator;
+import com.arellomobile.mvp.compiler.MvpCompiler;
 import com.arellomobile.mvp.viewstate.MvpViewState;
 import com.arellomobile.mvp.viewstate.ViewCommand;
 import com.squareup.javapoet.ClassName;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Random;
 
 import javax.lang.model.element.Modifier;
+import javax.lang.model.type.DeclaredType;
 
 import static com.arellomobile.mvp.compiler.Util.decapitalizeString;
 
@@ -32,6 +34,7 @@ public final class ViewStateClassGenerator extends JavaFilesGenerator<ViewInterf
 	public List<JavaFile> generate(ViewInterfaceInfo viewInterfaceInfo) {
 		ClassName viewName = viewInterfaceInfo.getName();
 		TypeName nameWithTypeVariables = viewInterfaceInfo.getNameWithTypeVariables();
+		DeclaredType viewInterfaceType = (DeclaredType) viewInterfaceInfo.getElement().asType();
 
 		TypeSpec.Builder classBuilder = TypeSpec.classBuilder(viewName.simpleName() + MvpProcessor.VIEW_STATE_SUFFIX)
 				.addModifiers(Modifier.PUBLIC)
@@ -42,7 +45,7 @@ public final class ViewStateClassGenerator extends JavaFilesGenerator<ViewInterf
 		for (ViewMethod method : viewInterfaceInfo.getMethods()) {
 			TypeSpec commandClass = generateCommandClass(method, nameWithTypeVariables);
 			classBuilder.addType(commandClass);
-			classBuilder.addMethod(generateMethod(method, nameWithTypeVariables, commandClass));
+			classBuilder.addMethod(generateMethod(viewInterfaceType, method, nameWithTypeVariables, commandClass));
 		}
 
 		JavaFile javaFile = JavaFile.builder(viewName.packageName(), classBuilder.build())
@@ -75,7 +78,8 @@ public final class ViewStateClassGenerator extends JavaFilesGenerator<ViewInterf
 		return classBuilder.build();
 	}
 
-	private MethodSpec generateMethod(ViewMethod method, TypeName viewTypeName, TypeSpec commandClass) {
+	private MethodSpec generateMethod(DeclaredType enclosingType, ViewMethod method,
+	                                  TypeName viewTypeName, TypeSpec commandClass) {
 		// TODO: String commandFieldName = "$cmd";
 		String commandFieldName = decapitalizeString(method.getCommandClassName());
 
@@ -85,7 +89,7 @@ public final class ViewStateClassGenerator extends JavaFilesGenerator<ViewInterf
 			commandFieldName += random.nextInt(10);
 		}
 
-		return MethodSpec.overriding(method.getElement())
+		return MethodSpec.overriding(method.getElement(), enclosingType, MvpCompiler.getTypeUtils())
 				.addStatement("$1N $2L = new $1N($3L)", commandClass, commandFieldName, method.getArgumentsString())
 				.addStatement("mViewCommands.beforeApply($L)", commandFieldName)
 				.addCode("\n")

--- a/moxy-compiler/src/test/resources/view/ExtendsOfGenericView$$State.java
+++ b/moxy-compiler/src/test/resources/view/ExtendsOfGenericView$$State.java
@@ -1,14 +1,15 @@
 package view;
 
-import com.arellomobile.mvp.MvpView;
-
+import com.arellomobile.mvp.viewstate.MvpViewState;
+import com.arellomobile.mvp.viewstate.ViewCommand;
+import com.arellomobile.mvp.viewstate.strategy.AddToEndStrategy;
 import java.io.Serializable;
+import java.lang.Override;
 
-public interface ExtendsOfGenericView extends GenericWithExtendsView<Serializable> {
-
+public class ExtendsOfGenericView$$State extends MvpViewState<ExtendsOfGenericView> implements ExtendsOfGenericView {
     @Override
     public void testEvent(Serializable param) {
-        ExtendsOfGenericView$$State.TestEventCommand testEventCommand = new ExtendsOfGenericView$$State.TestEventCommand(param);
+        TestEventCommand testEventCommand = new TestEventCommand(param);
         mViewCommands.beforeApply(testEventCommand);
 
         if (mViews == null || mViews.isEmpty()) {
@@ -22,12 +23,12 @@ public interface ExtendsOfGenericView extends GenericWithExtendsView<Serializabl
         mViewCommands.afterApply(testEventCommand);
     }
 
-
     public class TestEventCommand extends ViewCommand<ExtendsOfGenericView> {
         public final Serializable param;
 
         TestEventCommand(Serializable param) {
             super("testEvent", AddToEndStrategy.class);
+
             this.param = param;
         }
 
@@ -36,5 +37,4 @@ public interface ExtendsOfGenericView extends GenericWithExtendsView<Serializabl
             mvpView.testEvent(param);
         }
     }
-
 }


### PR DESCRIPTION
Fix issue #203

* Use javapoet `MethodBuilder#overriding(ExecutableElement, DeclaredType, Types)` which correctly fill generics.
* `Command` class generation fixed with usage of `Types#asMemberOf(...)` to resolve generics. Javapoet `overriding` does exactly the same thing internally but provides no easy way to use it without building a method.