### PR TITLE
Fix ClassCastException with local presenters

### DIFF
--- a/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
+++ b/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
@@ -263,7 +263,7 @@ public class MvpDelegate<Delegated> {
 	 */
 	private String generateTag() {
 		String tag = mParentDelegate != null ? mParentDelegate.mDelegateTag  + " " : "";
-		tag += mDelegated.getClass().getSimpleName() + "$" + getClass().getSimpleName() + toString().replace(getClass().getName(), "");
+		tag += mDelegated.getClass().getCanonicalName() + "$" + getClass().getSimpleName() + toString().replace(getClass().getName(), "");
 		return tag;
 	}
 }


### PR DESCRIPTION
After obfuscation, my local presenters have the same class name and field name in view. And in case when two MvpDelegate for each view have the same hashCode, generateTag() return equals tags for 2 different presenter. According MvpFacade.getInstance().getPresenterStore().get(tag); (In MvpProcessor) return already exist presenter, but type of the presenter are different. In result after call  of method bind() in PresenterBinder throw ClassCastException. I have already caught this exception.
