### PR TITLE
Fix ClassCastException with local presenters

### DIFF
--- a/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
+++ b/moxy/src/main/java/com/arellomobile/mvp/MvpDelegate.java
@@ -263,7 +263,7 @@ public class MvpDelegate<Delegated> {
 	 */
 	private String generateTag() {
 		String tag = mParentDelegate != null ? mParentDelegate.mDelegateTag  + " " : "";
-		tag += mDelegated.getClass().getSimpleName() + "$" + getClass().getSimpleName() + toString().replace(getClass().getName(), "");
+		tag += mDelegated.getClass().getCanonicalName() + "$" + getClass().getSimpleName() + toString().replace(getClass().getName(), "");
 		return tag;
 	}
 }


### PR DESCRIPTION
After obfuscation, the names of the presenter classes have the same name, as a result of which an error occurs when we get the presenter from the map and bring it to a certain type.